### PR TITLE
Use result of ptr_decay() in resolve_expr_unary()

### DIFF
--- a/ion/resolve.c
+++ b/ion/resolve.c
@@ -756,6 +756,7 @@ ResolvedExpr resolve_expr_unary(Expr *expr) {
     switch (expr->unary.op) {
     case TOKEN_MUL:
         operand = ptr_decay(operand);
+        type = operand.type;
         if (type->kind != TYPE_PTR) {
             fatal("Cannot deref non-ptr type");
         }


### PR DESCRIPTION
Testcase:

    const char *code[] = {
        "var p: int[2] = {1,2}",
        "var a = *p",
    }

Expected output:

    (var p (array int 2) (compound nil (nil 1) (nil 2)))
    (var a nil (* p))

Actual output:

    FATAL: Cannot deref non-ptr type