### PR TITLE
Add number groupings

### DIFF
--- a/ion/lex.c
+++ b/ion/lex.c
@@ -328,14 +328,17 @@ uint8_t char_to_digit[256] = {
 
 void scan_int(void) {
     int base = 10;
+    const char* digits_start = stream;
     if (*stream == '0') {
         stream++;
         if (tolower(*stream) == 'x') {
             stream++;
+            digits_start = stream;
             token.mod = MOD_HEX;
             base = 16;
         } else if (tolower(*stream) == 'b') {
             stream++;
+            digits_start = stream;
             token.mod = MOD_BIN;
             base = 2;
         } else if (isdigit(*stream)) {
@@ -347,7 +350,11 @@ void scan_int(void) {
     for (;;) {
         int digit = char_to_digit[(unsigned char)*stream];
         if (digit == 0 && *stream != '0') {
-            break;
+            if (stream == digits_start) {
+                error_here("Expected digits, got '%c'", *stream);
+            } else {
+                break;
+            }
         }
         if (digit >= base) {
             error_here("Digit '%c' out of range for base %d", *stream, base);

--- a/ion/lex.c
+++ b/ion/lex.c
@@ -352,6 +352,12 @@ void scan_int(void) {
         if (digit == 0 && *stream != '0') {
             if (stream == digits_start) {
                 error_here("Expected digits, got '%c'", *stream);
+            } else if (*stream == '_') {
+                stream++;
+                if (*stream == '_') {
+                    error_here("Unexpected repeated grouping character '_'");
+                    break;
+                }
             } else {
                 break;
             }

--- a/ion/test1.ion
+++ b/ion/test1.ion
@@ -278,7 +278,7 @@ func test_assign() {
     // f++;
     // f--;
 
-    
+
 }
 
 func benchmark(n: int) {
@@ -307,6 +307,7 @@ func test_lits() {
     x2 := 4294967295;
     x3 := 0xffffffffffffffff;
     x4 := 0b10101010 + 0b01010101;
+    x5 := 0x1200_3002;
 }
 
 func test_ops() {


### PR DESCRIPTION
Two small patches, the first is a bugfix, the second is a proposal to add _ as number grouping
separator to allow literals such as:

0x1200_00e0
123_456_789

