### PR TITLE
Include stddef.h in the Ion preamble to get ptrdiff_t

### DIFF
--- a/ion/gen.c
+++ b/ion/gen.c
@@ -14,6 +14,7 @@ const char *gen_preamble =
     "// Preamble\n"
     "#include <stdbool.h>\n"
     "#include <stdint.h>\n"
+    "#include <stddef.h>\n"
     "\n"
     "typedef unsigned char uchar;\n"
     "typedef signed char schar;\n"


### PR DESCRIPTION
Without this, Ion generated code won't compile on macOS.