### PR TITLE
Small additions to .uint8, .uint16 and .uint32

### DIFF
--- a/ion/forth.asm
+++ b/ion/forth.asm
@@ -4,6 +4,8 @@
 
         .reg t1 x8
         .reg t2 x9
+        .reg t3 x10
+        .reg t4 x11
 
         .macro next
         lw t1, [pc]
@@ -19,6 +21,15 @@ $name:
         .endmacro
 
 init:
+        la t1, init_msg         // Load the address of the string into t1
+        lb t2, [t1]             // Load the number of characters into t2
+1:      add t1, 1
+        lbu t3, [t1]            // Load a character into t3
+        sw putchar, t3, t4      // Output it
+        sub t2, 1
+        bne t2, x0, <1
+
+
         la sp, stack_start
         la pc, program_start
         $next
@@ -73,27 +84,21 @@ stack_start:
         .org 0x2000
 program_start:
         .uint32 do_getchar
-        .uint32 do_push
-        .uint32 -'0'
+        .uint32 do_push, -'0'
         .uint32 do_add
         .uint32 do_twice
         .uint32 do_twice
-        .uint32 do_push
-        .uint32 '0'
+        .uint32 do_push, '0'
         .uint32 do_add
         .uint32 do_putchar
-
         .uint32 do_getchar
-        .uint32 do_push
-        .uint32 -'0'
+        .uint32 do_push, -'0'
         .uint32 do_add
         .uint32 do_getchar
-        .uint32 do_push
-        .uint32 -'0'
+        .uint32 do_push, -'0'
         .uint32 do_add
         .uint32 do_add
-        .uint32 do_push
-        .uint32 '0'
+        .uint32 do_push, '0'
         .uint32 do_add
         .uint32 do_putchar
         .uint32 do_getchar
@@ -104,6 +109,9 @@ do_twice:
 1:      .uint32 do_dup
         .uint32 do_add
         .uint32 do_exit
+
+init_msg:
+        .uint8 14, "Hello, World!\n"
 
     .org 0xFFFFFF00
 getchar:

--- a/ion/forth.asm
+++ b/ion/forth.asm
@@ -21,15 +21,6 @@ $name:
         .endmacro
 
 init:
-        la t1, init_msg         // Load the address of the string into t1
-        lb t2, [t1]             // Load the number of characters into t2
-1:      add t1, 1
-        lbu t3, [t1]            // Load a character into t3
-        sw putchar, t3, t4      // Output it
-        sub t2, 1
-        bne t2, x0, <1
-
-
         la sp, stack_start
         la pc, program_start
         $next
@@ -109,9 +100,6 @@ do_twice:
 1:      .uint32 do_dup
         .uint32 do_add
         .uint32 do_exit
-
-init_msg:
-        .uint8 14, "Hello, World!\n"
 
     .org 0xFFFFFF00
 getchar:

--- a/ion/riscv/assembler.ion
+++ b/ion/riscv/assembler.ion
@@ -1372,24 +1372,37 @@ func cmd_set(asm: Assembler*) {
 }
 
 func cmd_uint8(asm: Assembler*) {
-    imm := parse_const(asm);
-    asm_uint8(asm, uint8(imm));
+    do {
+        if(is_token(asm, TOKEN_STR)) {
+            for(str := asm.token.str; *str != 0; str++) {
+                asm_uint8(asm, uint8(*str));
+            }
+            next_token(asm);
+        } else {
+            imm := parse_const(asm);
+            asm_uint8(asm, uint8(imm));
+        }
+    } while(match_token(asm, TOKEN_COMMA));
 }
 
 func cmd_uint16(asm: Assembler*) {
-    imm := parse_const(asm);
-    asm_uint16(asm, uint16(imm));
+    do {
+        imm := parse_const(asm);
+        asm_uint16(asm, uint16(imm));
+    } while(match_token(asm, TOKEN_COMMA));
 }
 
 func cmd_uint32(asm: Assembler*) {
-    expr := parse_expr(asm);
-    @complete
-    switch (expr.kind) {
-    case EXPR_CONST:
-        asm_uint32(asm, uint32(expr.val));
-    case EXPR_ADDR:
-        asm_uint32(asm, expr.addr);
-    }
+    do {
+        expr := parse_expr(asm);
+        @complete
+        switch (expr.kind) {
+        case EXPR_CONST:
+            asm_uint32(asm, uint32(expr.val));
+        case EXPR_ADDR:
+            asm_uint32(asm, expr.addr);
+        }
+    } while(match_token(asm, TOKEN_COMMA));
 }
 
 func cmd_fill(asm: Assembler*) {


### PR DESCRIPTION
I added the ability to specify multiple numbers at once for the `.uint` commands, i.e. you can now specify 
```
.uint32 1, 2, 3, 4
```
and it will assemble all four values into the buffer.

In addition, `.uint8` now supports string literals;
```
.uint8 "Hello, World!"
```
will assemble the ascii valules of the characters into the buffer.
The string is **not** zero-terminated automatically; to assemble a C-style zero-terminated string, use `.uint8 "test", 0`; for a FORTH-style length-prefixed string, use `.uint8 4, "test"`