### PR TITLE
Add enum typeinfos

### DIFF
--- a/ion/gen.c
+++ b/ion/gen.c
@@ -470,6 +470,7 @@ const char *typeid_kind_names[NUM_TYPE_KINDS] = {
     [TYPE_ULONG] = "TYPE_ULONG",
     [TYPE_LLONG] = "TYPE_LLONG",
     [TYPE_ULLONG] = "TYPE_ULLONG",
+    [TYPE_ENUM] = "TYPE_ENUM",
     [TYPE_FLOAT] = "TYPE_FLOAT",
     [TYPE_DOUBLE] = "TYPE_DOUBLE",
     [TYPE_CONST] = "TYPE_CONST",
@@ -1157,11 +1158,16 @@ void gen_typeinfo(Type *type) {
         gen_typeinfo_fields(type);
         genlnf("}},");
         break;
+    case TYPE_ENUM:
+        gen_typeinfo_header("TYPE_ENUM", type);
+        genf(", .name = ");
+        gen_str(get_gen_name(type->sym), false);
+        genf(", .base = ");
+        gen_typeid(type->base);
+        genf("},");
+        break;
     case TYPE_FUNC:
         genf("NULL, // Func");
-        break;
-    case TYPE_ENUM:
-        genf("NULL, // Enum");
         break;
     case TYPE_INCOMPLETE:
         genf("NULL, // Incomplete: %s", get_gen_name(type->sym));

--- a/ion/gen.c
+++ b/ion/gen.c
@@ -1102,6 +1102,16 @@ void gen_typeinfo_fields(Type *type) {
     gen_indent--;
 }
 
+void gen_typeinfo_enum_items(Type *type) {
+    gen_indent++;
+    for (size_t i = 0; i < type->enumeration.num_enum_items; i++) {
+        TypeEnumItem enum_item = type->enumeration.enum_items[i];
+        const char* name = get_gen_name(enum_item.sym);
+        genf("{ .name = \"%s\", .int_value = %s },", name, name);
+    }
+    gen_indent--;
+}
+
 #define CASE(kind, name) \
     case kind: \
         genf("&(TypeInfo){" #kind ", .size = sizeof(" #name "), .align = sizeof(" #name "), .name = "); \
@@ -1164,7 +1174,9 @@ void gen_typeinfo(Type *type) {
         gen_str(get_gen_name(type->sym), false);
         genf(", .base = ");
         gen_typeid(type->base);
-        genf("},");
+        genf(", .num_enum_items = %d, .enum_items = (TypeEnumItemInfo[]) {", type->enumeration.num_enum_items);
+        gen_typeinfo_enum_items(type);
+        genf("}},");
         break;
     case TYPE_FUNC:
         genf("NULL, // Func");

--- a/ion/system_packages/builtin/typeinfo.ion
+++ b/ion/system_packages/builtin/typeinfo.ion
@@ -15,6 +15,7 @@ enum TypeKind {
     TYPE_ULONG,
     TYPE_LLONG,
     TYPE_ULLONG,
+    TYPE_ENUM,
     TYPE_FLOAT,
     TYPE_DOUBLE,
     TYPE_CONST,

--- a/ion/system_packages/builtin/typeinfo.ion
+++ b/ion/system_packages/builtin/typeinfo.ion
@@ -32,6 +32,11 @@ struct TypeFieldInfo {
     offset: int;
 }
 
+struct TypeEnumItemInfo {
+    name: char const*;
+    int_value: int64; // base type is enough to represent these values
+}
+
 struct TypeInfo {
     kind: TypeKind;
     size: int;
@@ -41,6 +46,8 @@ struct TypeInfo {
     base: typeid;
     fields: TypeFieldInfo*;
     num_fields: int;
+    enum_items: TypeEnumItemInfo*;
+    num_enum_items: int;
 }
 
 @foreign

--- a/ion/test1/subtest1/subtest1.ion
+++ b/ion/test1/subtest1/subtest1.ion
@@ -1,5 +1,9 @@
 import LIBC = libc {printf}
 
+enum SubOptions {
+    SubOptions_I, SubOptions_J, SubOptions_K,
+}
+
 func bogus_func() {
     printf("Hello, world!\n");
 //    asdf;

--- a/ion/test1/test1.ion
+++ b/ion/test1/test1.ion
@@ -510,10 +510,53 @@ func print_any(any: Any) {
     case typeof(float):
         printf("%f", *(:float const *)any.ptr);
     default:
-        printf("<unknown>");
+        typeinfo := get_typeinfo(any.type);
+        if (typeinfo.kind == TYPE_ENUM) {
+            value := int64_from_integer({any.ptr, typeinfo.base});
+            enum_item: TypeEnumItemInfo*;
+            for (i:=0; i < typeinfo.num_enum_items; i++) {
+                if (typeinfo.enum_items[i].int_value == value) {
+                    enum_item = &typeinfo.enum_items[i];
+                }
+            }
+            if (!enum_item) {
+                printf("%lld (undefined enum item)", value);
+            } else {
+                printf("%lld (%s)", enum_item.int_value, enum_item.name);
+            }
+        } else {
+            printf("<unknown>");
+        }
     }
     printf(": ");
     print_type(any.type);
+}
+
+func int64_from_integer(any: Any) : int64 {
+    switch(any.type) {
+        case typeof(uint): {
+            return *(:uint const*) any.ptr;
+        }
+        case typeof(int): {
+            return *(:int const*) any.ptr;
+        }
+        case typeof(ulong): {
+            return *(:ulong const*) any.ptr;
+        }
+        case typeof(long): {
+            return *(:long const*) any.ptr;
+        }
+        case typeof(llong): {
+            return *(:llong const*) any.ptr;
+        }
+        case typeof(ullong): {
+            return *(:ullong const*) any.ptr;
+        }
+        default: {
+            #assert(false);
+            return 0;
+        }
+    }
 }
 
 func println_any(any: Any) {
@@ -569,6 +612,13 @@ func print_typeinfo(type: typeid) {
     case TYPE_ENUM:
         printf(" enum=");
         print_type(typeinfo.base);
+        printf(" { ");
+        prefix := "";
+        for (i:=0; i<typeinfo.num_enum_items; i++) {
+            printf("%s%s=%lld", prefix, typeinfo.enum_items[i].name, typeinfo.enum_items[i].int_value);
+            prefix = ", ";
+        }
+        printf(" }");
     case TYPE_STRUCT, TYPE_UNION:
         printf(" %s={ ", typeinfo.kind == TYPE_STRUCT ? "struct" : "union");
         for (i := 0; i < typeinfo.num_fields; i++) {
@@ -616,6 +666,13 @@ func test_typeinfo() {
     o := Options_B;
     println_any({&o, typeof(o)});
     println_typeinfo(typeof(o));
+
+    o = 32;
+    println_any({&o, typeof(o)});
+
+    so := subtest1.SubOptions_I;
+    println_any({&so, typeof(so)});
+    println_typeinfo(typeof(so));
 }
 
 struct Ints {

--- a/ion/test1/test1.ion
+++ b/ion/test1/test1.ion
@@ -566,6 +566,9 @@ func print_typeinfo(type: typeid) {
     print_type(type);
     printf(" size=%d align=%d", typeinfo.size, typeinfo.align);
     switch (typeinfo.kind) {
+    case TYPE_ENUM:
+        printf(" enum=");
+        print_type(typeinfo.base);
     case TYPE_STRUCT, TYPE_UNION:
         printf(" %s={ ", typeinfo.kind == TYPE_STRUCT ? "struct" : "union");
         for (i := 0; i < typeinfo.num_fields; i++) {
@@ -582,6 +585,12 @@ func print_typeinfo(type: typeid) {
 func println_typeinfo(type: typeid) {
     print_typeinfo(type);
     printf("\n");
+}
+
+enum Options {
+  Options_A,
+  Options_B,
+  Options_C,
 }
 
 func test_typeinfo() {
@@ -602,6 +611,11 @@ func test_typeinfo() {
     println_typeinfo(typeof(UartCtrl));
     println_typeinfo(typeof(:IntOrPtr*));
     println_typeinfo(typeof(IntOrPtr));
+
+    // Demonstrate typeinfos for enums:
+    o := Options_B;
+    println_any({&o, typeof(o)});
+    println_typeinfo(typeof(o));
 }
 
 struct Ints {

--- a/ion/type.c
+++ b/ion/type.c
@@ -36,6 +36,10 @@ typedef struct TypeField {
     size_t offset;
 } TypeField;
 
+typedef struct TypeEnumItem {
+    Sym *sym;
+} TypeEnumItem;
+
 struct Type {
     TypeKind kind;
     size_t size;
@@ -50,6 +54,10 @@ struct Type {
             TypeField *fields;
             size_t num_fields;
         } aggregate;
+        struct {
+          TypeEnumItem *enum_items;
+          size_t num_enum_items;
+        } enumeration;
         struct {
             Type **params;
             size_t num_params;
@@ -428,12 +436,18 @@ Type *type_incomplete(Sym *sym) {
     return type;
 }
 
-Type *type_enum(Sym *sym, Type *base) {
+Type *type_enum(Sym *sym, Type *base, TypeEnumItem* items, size_t num_items) {
     Type *type = type_alloc(TYPE_ENUM);
     type->sym = sym;
     type->base = base;
     type->size = type_int->size;
     type->align = type_int->align;
+    TypeEnumItem *enum_items = NULL;
+    for (TypeEnumItem *it = items; it < items + num_items; it++) {
+        buf_push(enum_items, *it);
+    }
+    type->enumeration.num_enum_items = buf_len(enum_items);
+    type->enumeration.enum_items = enum_items;
     return type;
 }
 


### PR DESCRIPTION
This introduces type information for enum types.

The ion program can now know that a type is an enum, and what is its base type and size as well as
the values of available constants in the enum (see `enum_items` and `num_enum_items`)

This allows user programs to print the friendly enumeration constant associated with a value, or validate
that a value is a legal one.

The name of the constant is the external C name, i.e. as mangled into the C symbols, similarly to how
type names are also introspected. This guarantees unicity, however means that a ion program looking
to generate new ion programs would have to reverse the manging somehow. The same issue is true
for existing type names however.

Note that this creates a distinction between enum constants and plain constants: enum constants are
known to the program and can be shared outside. This matches my experience of using enumerations
in applications.

Initially I wanted to supply sorted arrays for an enumeration type by name and value, to make lookups
more efficient. However to do this at compile time would necessitate the ion to evaluate the
enum expression. Right now the value of the expression is only known to the ion program (after the
C compiler has done its job)

So fast lookups (sub-O(n)) for large enumerations will have to be done by hand in the ion
program for now.
